### PR TITLE
Disable increment on User model

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -36,6 +36,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      * @var string
      */
     protected $primaryKey = 'username';
+    
+    public $incrementing = false;
 
     public function profiles()
     {


### PR DESCRIPTION
Ini yang menyebabkan setiap kali menambahkan `username` (as primary key) value-nya selalu 0.
Solusinya dengan men-*disable* increment.